### PR TITLE
#15 Changed the link to the code of conduct for pupet

### DIFF
--- a/moduleroot/CONTRIBUTING.md
+++ b/moduleroot/CONTRIBUTING.md
@@ -5,7 +5,7 @@ will likely make it into a release a little quicker.
 
 ## Contributing
 
-Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms. [Contributor Code of Conduct](http://contributor-covenant.org/version/1/2/0/).
+Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms. [Contributor Code of Conduct](https://github.com/puppet-community/code-of-conduct).
 
 1. Fork the repo.
 


### PR DESCRIPTION
Fixes #15 Linked to the specific code of conduct from the puppet-community repo. Adapted from http://contributor-covenant.org/version/1/2/0/