### PR TITLE
This adds support for specifying additional rubocop excludes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 AllCops:
+  Include:
+    - ./**/*.rb
   Exclude:
     - moduleroot/spec/spec_helper.rb
     - vendor/**/*

--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -3,6 +3,9 @@ AllCops:
     - vendor/**/*
     - pkg/**/*
     - spec/fixtures/**/*
+    <%- @configs['AllCops']['Exclude'].each do |x| -%>
+    - <%= x %>
+    <%- end -%>
 
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:


### PR DESCRIPTION
Tag @igalic. This is what I need to help implement https://github.com/puppet-community/puppet-mcollective/pull/249. It allows us to specify things for rubocop to ignore on a per-project basis.