### PR TITLE
We now manage puppet-mcollective

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -7,3 +7,4 @@
 - puppet-confluence
 - puppet-mysql_java_connector
 - puppet-rundeck
+- puppet-mcollective


### PR DESCRIPTION
With #30 and #31 merged, we now support puppet-mcollective.