### PR TITLE
Add vagrant-wrapper to Gemfile

### DIFF
--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -26,6 +26,7 @@ group :development do
 end
 
 group :system_tests do
+  gem 'vagrant-wrapper'
   gem 'beaker'
   gem 'beaker-rspec'
 end


### PR DESCRIPTION
Resolves the below error when running beaker locally using vagrant:

```
created Vagrantfile for VagrantHost ubuntu-server-1404-x64
/home/mk/.rvm/gems/ruby-2.1.5/gems/beaker-2.27.0/lib/beaker/hypervisor/vagrant.rb:190:in
`block (2 levels) in vagrant_cmd': Failed to exec 'vagrant up'. Error
was
/home/mk/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/rubygems_integration.rb:256:in
`block in replace_gem': vagrant-wrapper is not part of the bundle. Add
it to Gemfile. (Gem::LoadError) (RuntimeError)
```