### PR TITLE
Disable rubocop warnings on documentation

### DIFF
--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -54,3 +54,7 @@ Style/WordArray:
 # providers
 Style/ClassAndModuleChildren:
   Enabled: false
+
+Style/Documentation:
+  Description: 'Document classes and non-namespace modules.'
+  Enabled: false


### PR DESCRIPTION
This fixes #14 a bit more.

https://github.com/puppet-community/puppet-rundeck/pull/146 was failing on a docs comment, and we really shouldn't be that strict.