### PR TITLE
Only call template additions if they're not nil.

### DIFF
--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -5,8 +5,10 @@ AllCops:
     - vendor/**/*
     - pkg/**/*
     - spec/fixtures/**/*
+    <%- if !@configs.nil? and @configs.has_key?('AllCops') and @configs['AllCops'].has_key?('Exclude') -%>
     <%- @configs['AllCops']['Exclude'].each do |x| -%>
     - <%= x %>
+    <%- end -%>
     <%- end -%>
 
 # Configuration parameters: AllowURI, URISchemes.


### PR DESCRIPTION
Fixes https://github.com/puppet-community/modulesync/issues/64