### PR TITLE
We now manage puppet-archive

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -8,3 +8,4 @@
 - puppet-mysql_java_connector
 - puppet-rundeck
 - puppet-mcollective
+- puppet-archive


### PR DESCRIPTION
We now manage puppet-archive, via https://github.com/puppet-community/puppet-archive/pull/82