### PR TITLE
Align configuration a bit closer to the Puppetlabs one

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 group :test do
   gem 'rake'

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,17 +1,14 @@
 ---
 .travis.yml:
-  script: "\"bundle exec rake validate lint spec SPEC_OPTS='--format documentation'\""
   includes:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.1.5
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.1.5
-    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
-  - rvm: 2.1.6
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+  - rvm: 2.1.7
+    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
+  - rvm: 2.1.7
+    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+  - rvm: 2.2.3
+    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+  - rvm: 2.2.3
+    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
 Gemfile:
   required:
     ':test':
@@ -39,4 +36,12 @@ Gemfile:
     ':system_tests':
       - gem: beaker
       - gem: beaker-rspec
+      - gem: beaker-puppet_install_helper
+Rakefile:
+  default_disabled_lint_checks:
+  - 'relative'
+  - 'disable_80chars'
+  - 'disable_class_inherits_from_params_class'
+  - 'disable_documentation'
+  - 'disable_single_quote_string_with_variables'
 ...

--- a/moduleroot/.gitignore
+++ b/moduleroot/.gitignore
@@ -1,6 +1,16 @@
-.*.sw?
-pkg
-spec/fixtures
-.rspec_system
-.vagrant
+pkg/
 Gemfile.lock
+vendor/
+spec/fixtures/
+.vagrant/
+.bundle/
+coverage/
+log/
+.idea/
+*.iml
+.*.sw
+<% if ! @configs['paths'].nil? -%>
+<% @configs['paths'].each do |path| -%>
+<%= path %>
+<% end -%>
+<% end -%>

--- a/moduleroot/.rspec
+++ b/moduleroot/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -1,6 +1,4 @@
 ---
-notifications:
-  email: false
 sudo: false
 language: ruby
 cache: bundler
@@ -29,18 +27,25 @@ script:
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.4" CHECK=test
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.1.6
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.1.6
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.2.3
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.2.3
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
+<% @configs['includes'].each do |include| -%>
+  - rvm: <%= include['rvm'] %>
+    env: <%= include['env'] %>
+<% end -%>
+<% if @configs['extras'] -%>
+<%   @configs['extras'].each do |extra| -%>
+  - rvm: <%= extra['rvm'] %>
+    env: <%= extra['env'] %>
+<%   end -%>
+<% end -%>
+<% if @configs['allow_failures'] -%>
+<%   @configs['allow_failures'].each do |allow_failures| -%>
+  allow_failures:
+    - rvm: <%= allow_failures['rvm'] %>
+      env: <%= allow_failures['env'] %>
+<%   end -%>
+<% end -%>
+notifications:
+  email: false
 deploy:
   provider: puppetforge
   user: puppet

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -1,4 +1,4 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 def location_for(place, fake_version = nil)
   if place =~ /^(git[:@][^#]*)#(.*)/
@@ -9,15 +9,6 @@ def location_for(place, fake_version = nil)
     [place, { :require => false }]
   end
 end
-
-if facterversion = ENV['FACTER_GEM_VERSION']
-gem 'facter', facterversion.to_s, :require => false, :groups => [:test]
-else
-gem 'facter', :require => false, :groups => [:test]
-end
-
-ENV['PUPPET_VERSION'].nil? ? puppetversion = '3.8.4' : puppetversion = ENV['PUPPET_VERSION'].to_s
-gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 <% groups = {} -%>
 <% (@configs['required'].keys + ((@configs['optional'] || {}).keys)).uniq.each do |key| -%>
@@ -54,4 +45,15 @@ group <%= group %> do
 end
 
 <% end -%>
+
+
+if facterversion = ENV['FACTER_GEM_VERSION']
+gem 'facter', facterversion.to_s, :require => false, :groups => [:test]
+else
+gem 'facter', :require => false, :groups => [:test]
+end
+
+ENV['PUPPET_VERSION'].nil? ? puppetversion = '3.8.4' : puppetversion = ENV['PUPPET_VERSION'].to_s
+gem 'puppet', puppetversion, :require => false, :groups => [:test]
+
 # vim:ft=ruby

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -7,16 +7,12 @@ require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 
-PuppetLint.configuration.relative = true
-PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{check}:%{KIND}:%{message}'
 PuppetLint.configuration.fail_on_warnings = true
-
-# Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
-# http://puppet-lint.com/checks/class_parameter_defaults/
-PuppetLint.configuration.send('disable_class_parameter_defaults')
-# http://puppet-lint.com/checks/class_inherits_from_params_class/
-PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+<% checks = @configs['default_disabled_lint_checks'] + ( @configs['extra_disabled_lint_checks'] || [] ) -%>
+<% checks.each do |check| -%>
+PuppetLint.configuration.send('<%= check %>')
+<% end -%>
 
 exclude_paths = %w(
   pkg/**/*

--- a/moduleroot/spec/spec.opts
+++ b/moduleroot/spec/spec.opts
@@ -1,6 +1,0 @@
---format
-s
---colour
---loadby
-mtime
---backtrace


### PR DESCRIPTION
- Use a broader .gitignore
- Use config includes/extras/allow_failures and don't hardcode
  rvm/puppet versions in .travis.yml
- Use .rspec rather than rspec.opts
- Don't hardcode disabled lint options

In addition:
- Reduce the default Gem/Puppet set to recent versions
- Be slightly more lenient on lint checks