### PR TITLE
fix (travis) Gemfile uses PUPPET_VERSION, our env should too

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -2,13 +2,13 @@
 .travis.yml:
   includes:
   - rvm: 2.1.7
-    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.1.7
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.2.3
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.2.3
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
 Gemfile:
   required:
     ':test':


### PR DESCRIPTION
after aligning our .dotfiles to those of puppetlabs, our Gemfile and our
.travis.yml's defaults are now a bit out of whack: they use different
environment variables for puppet's version. This pr aligns them.