### PR TITLE
fix (rvm) bring back 1.9.3 testing

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,6 +1,8 @@
 ---
 .travis.yml:
   includes:
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.1.7
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.1.7


### PR DESCRIPTION
while we have decided some time ago to discontinue our testing of 1.8.7,
we have not made such a decision for 1.9.3. And i believe, despite the fact
that 1.9.3 is eol, too, we *cannot* make that move just yet.